### PR TITLE
separate reserves plots, fix factor issue with bar plots, fix reserve…

### DIFF
--- a/src/PowerGraphics.jl
+++ b/src/PowerGraphics.jl
@@ -33,6 +33,7 @@ include("plot_results.jl")
 include("definitions.jl")
 include("fuel_results.jl")
 include("plot_recipes.jl")
+include("plotly_recipes.jl")
 include("call_plots.jl")
 
 function __init__()

--- a/src/call_plots.jl
+++ b/src/call_plots.jl
@@ -247,7 +247,8 @@ function fuel_plot(results::Array, generator_dict::Dict; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    time_interval = IS.get_time_stamp(results[1])[2, 1] - IS.get_time_stamp(results[1])[1, 1]
+    time_interval =
+        IS.get_time_stamp(results[1])[2, 1] - IS.get_time_stamp(results[1])[1, 1]
     interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
     return _fuel_plot_internal(
         stack,
@@ -299,7 +300,15 @@ function bar_plot(res::IS.Results; kwargs...)
     end
     time_interval = IS.get_time_stamp(res)[2, 1] - IS.get_time_stamp(res)[1, 1]
     interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
-    return _bar_plot_internal(res, backend, save_fig, set_display, interval, reserves; kwargs...)
+    return _bar_plot_internal(
+        res,
+        backend,
+        save_fig,
+        set_display,
+        interval,
+        reserves;
+        kwargs...,
+    )
 end
 
 """
@@ -345,7 +354,15 @@ function bar_plot(results::Array; kwargs...)
     end
     time_interval = IS.get_time_stamp(res[1])[2, 1] - IS.get_time_stamp(res[1])[1, 1]
     interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
-    return _bar_plot_internal(res, backend, save_fig, set_display, interval, reserve_list; kwargs...)
+    return _bar_plot_internal(
+        res,
+        backend,
+        save_fig,
+        set_display,
+        interval,
+        reserve_list;
+        kwargs...,
+    )
 end
 
 function bar_plot(res::IS.Results, variables::Array; kwargs...)
@@ -465,7 +482,14 @@ function stack_plot(results::Array{}; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    return _stack_plot_internal(new_results, backend, save_fig, set_display, reserve_list; kwargs...)
+    return _stack_plot_internal(
+        new_results,
+        backend,
+        save_fig,
+        set_display,
+        reserve_list;
+        kwargs...,
+    )
 end
 
 """

--- a/src/call_plots.jl
+++ b/src/call_plots.jl
@@ -1,23 +1,14 @@
 function _filter_variables(results::IS.Results; kwargs...)
-    filter_results = Dict()
+    filter_variables = Dict()
     filter_parameters = Dict()
     results = _filter_parameters(results)
     for (key, var) in IS.get_variables(results)
-        if startswith("$key", "P") | any(key .== [:γ⁻__P, :γ⁺__P])
-            filter_results[key] = var
-        end
-    end
-    reserves = get(kwargs, :reserves, false)
-    if reserves
-        for (key, var) in IS.get_variables(results)
-            start = split("$key", "_")[1]
-            if in(start, VARIABLE_TYPES)
-                filter_results[key] = var
-            end
+        if startswith("$key", "P__") | any(key .== [:γ⁻__P, :γ⁺__P])
+            filter_variables[key] = var
         end
     end
     curtailment = get(kwargs, :curtailment, false)
-    _filter_curtailment!(results, filter_results, curtailment)
+    _filter_curtailment!(results, filter_variables, curtailment)
     load = get(kwargs, :load, false)
     if load
         filter_parameters[:P__PowerLoad] = results.parameter_values[:P__PowerLoad]
@@ -25,7 +16,7 @@ function _filter_variables(results::IS.Results; kwargs...)
 
     new_results = Results(
         IS.get_base_power(results),
-        filter_results,
+        filter_variables,
         IS.get_optimizer_log(results),
         IS.get_total_cost(results),
         IS.get_time_stamp(results),
@@ -33,6 +24,31 @@ function _filter_variables(results::IS.Results; kwargs...)
         filter_parameters,
     )
     return new_results
+end
+
+function _filter_reserves(results::IS.Results, reserves::Bool)
+    filter_up_reserves = Dict()
+    filter_down_reserves = Dict()
+    if reserves
+        for (key, var) in IS.get_variables(results)
+            if occursin("__", "$key")
+                ending = split("$key", "__")[2]
+                if in(ending, UP_RESERVES)
+                    filter_up_reserves[key] = var
+                elseif in(ending, DOWN_RESERVES)
+                    filter_down_reserves[key] = var
+                end
+            end
+        end
+        if isempty(filter_up_reserves) && isempty(filter_down_reserves)
+            @warn "No reserves found in results."
+            return nothing
+        else
+            return Dict("Up" => filter_up_reserves, "Down" => filter_down_reserves)
+        end
+    else
+        return nothing
+    end
 end
 
 function _filter_curtailment!(results::IS.Results, filter_results::Dict, curtailment::Bool)
@@ -197,6 +213,8 @@ function fuel_plot(res::IS.Results, generator_dict::Dict; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
+    time_interval = IS.get_time_stamp(res)[2, 1] - IS.get_time_stamp(res)[1, 1]
+    interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
     return _fuel_plot_internal(
         stack,
         bar,
@@ -205,7 +223,8 @@ function fuel_plot(res::IS.Results, generator_dict::Dict; kwargs...)
         save_fig,
         set_display,
         title,
-        ylabel;
+        ylabel,
+        interval;
         kwargs...,
     )
 end
@@ -228,6 +247,8 @@ function fuel_plot(results::Array, generator_dict::Dict; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
+    time_interval = IS.get_time_stamp(results[1])[2, 1] - IS.get_time_stamp(results[1])[1, 1]
+    interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
     return _fuel_plot_internal(
         stack,
         bar,
@@ -236,7 +257,8 @@ function fuel_plot(results::Array, generator_dict::Dict; kwargs...)
         save_fig,
         set_display,
         title,
-        ylabel;
+        ylabel,
+        interval;
         kwargs...,
     )
 end
@@ -269,11 +291,15 @@ function bar_plot(res::IS.Results; kwargs...)
     backend = Plots.backend()
     set_display = get(kwargs, :display, true)
     save_fig = get(kwargs, :save, nothing)
+    reserve = get(kwargs, :reserves, false)
+    reserves = _filter_reserves(res, reserve)
     res = _filter_variables(res; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    return _bar_plot_internal(res, backend, save_fig, set_display; kwargs...)
+    time_interval = IS.get_time_stamp(res)[2, 1] - IS.get_time_stamp(res)[1, 1]
+    interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
+    return _bar_plot_internal(res, backend, save_fig, set_display, interval, reserves; kwargs...)
 end
 
 """
@@ -305,15 +331,21 @@ function bar_plot(results::Array; kwargs...)
     backend = Plots.backend()
     set_display = get(kwargs, :display, true)
     save_fig = get(kwargs, :save, nothing)
-    res = _filter_variables(results[1]; kwargs...)
-    for i in 2:size(results, 1)
-        filter = _filter_variables(results[i]; kwargs...)
-        res = hcat(res, filter)
+    reserve = get(kwargs, :reserves, false)
+    reserve_list = []
+    res = []
+    for result in results
+        reserve_list = vcat(reserve_list, _filter_reserves(result, reserve))
+        res = vcat(res, _filter_variables(result; kwargs...))
     end
+    #res = hcat(res...)
+    #reserve_list = hcat(reserve_list...) 
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    return _bar_plot_internal(res, backend, save_fig, set_display; kwargs...)
+    time_interval = IS.get_time_stamp(res[1])[2, 1] - IS.get_time_stamp(res[1])[1, 1]
+    interval = Dates.Millisecond(Dates.Hour(1)) / time_interval
+    return _bar_plot_internal(res, backend, save_fig, set_display, interval, reserve_list; kwargs...)
 end
 
 function bar_plot(res::IS.Results, variables::Array; kwargs...)
@@ -382,11 +414,14 @@ function stack_plot(res::IS.Results; kwargs...)
     set_display = get(kwargs, :set_display, true)
     backend = Plots.backend()
     save_fig = get(kwargs, :save, nothing)
+    reserve = get(kwargs, :reserves, false)
+    reserves = _filter_reserves(res, reserve)
+
     res = _filter_variables(res; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    return _stack_plot_internal(res, backend, save_fig, set_display; kwargs...)
+    return _stack_plot_internal(res, backend, save_fig, set_display, reserves; kwargs...)
 end
 
 """
@@ -418,15 +453,19 @@ function stack_plot(results::Array{}; kwargs...)
     set_display = get(kwargs, :set_display, true)
     backend = Plots.backend()
     save_fig = get(kwargs, :save, nothing)
-    new_results = _filter_variables(results[1]; kwargs...)
-    for res in 2:length(results)
-        filtered = _filter_variables(results[res]; kwargs...)
-        new_results = hcat(new_results, filtered)
+    reserves = get(kwargs, :reserves, false)
+    reserve_list = []
+    new_results = []
+    for res in results
+        reserve_list = vcat(reserve_list, _filter_reserves(res, reserves))
+        new_results = vcat(new_results, _filter_variables(res; kwargs...))
     end
+    #new_results = hcat(new_results...)
+    #reserves_list = hcat(reserves_list...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
-    return _stack_plot_internal(new_results, backend, save_fig, set_display; kwargs...)
+    return _stack_plot_internal(new_results, backend, save_fig, set_display, reserve_list; kwargs...)
 end
 
 """
@@ -504,10 +543,23 @@ function _make_ylabel(base_power::Float64)
     return ylabel
 end
 
+function _make_bar_ylabel(base_power::Float64)
+    if isapprox(base_power, 1)
+        ylabel = "Generation (MWh)"
+    elseif isapprox(base_power, 100)
+        ylabel = "Generation (GWh)"
+    else
+        ylabel = "Generation (MWh x$base_power)"
+    end
+    return ylabel
+end
+
 function stair_plot(res::IS.Results; kwargs...)
     set_display = get(kwargs, :set_display, true)
     backend = Plots.backend()
     save_fig = get(kwargs, :save, nothing)
+    reserve = get(kwargs, :reserves, false)
+    reserves = _filter_reserves(res, reserve)
     res = _filter_variables(res; kwargs...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
@@ -516,7 +568,8 @@ function stair_plot(res::IS.Results; kwargs...)
         res,
         backend,
         save_fig,
-        set_display;
+        set_display,
+        reserves;
         stairs = "hv",
         linetype = :steppost,
         kwargs...,
@@ -527,11 +580,15 @@ function stair_plot(results::Array; kwargs...)
     set_display = get(kwargs, :set_display, true)
     backend = Plots.backend()
     save_fig = get(kwargs, :save, nothing)
-    new_results = _filter_variables(results[1]; kwargs...)
-    for res in 2:length(results)
-        filtered = _filter_variables(results[res]; kwargs...)
-        new_results = hcat(new_results, filtered)
+    reserves = get(kwargs, :reserves, false)
+    new_results = []
+    reserves_list = []
+    for res in results
+        reserves_list = vcat(reserves_list, _filter_reserves(res, reserves))
+        new_results = vcat(new_results, _filter_variables(res; kwargs...))
     end
+    #reserves_list = hcat(reserves_list...)
+    #new_results = hcat(new_results...)
     if isnothing(backend)
         throw(IS.ConflictingInputsError("No backend detected. Type gr() to set a backend."))
     end
@@ -539,7 +596,8 @@ function stair_plot(results::Array; kwargs...)
         new_results,
         backend,
         save_fig,
-        set_display;
+        set_display,
+        reserves_list;
         stairs = "hv",
         linetype = :steppost,
         kwargs...,

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -69,6 +69,16 @@ SUPPORTEDSERVICEPARAMS = [
     "StaticReserve_ReserveDown",
 ]
 
+UP_RESERVES = [
+    "VariableReserve_ReserveUp",
+    "StaticReserve_ReserveUp",
+]
+
+DOWN_RESERVES = [
+    "VariableReserve_ReserveDown",
+    "StaticReserve_ReserveDown",
+]
+
 OVERGENERATION_VARIABLE = :γ⁻__P
 UNSERVEDENERGY_VARIABLE = :γ⁺__P
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -69,15 +69,9 @@ SUPPORTEDSERVICEPARAMS = [
     "StaticReserve_ReserveDown",
 ]
 
-UP_RESERVES = [
-    "VariableReserve_ReserveUp",
-    "StaticReserve_ReserveUp",
-]
+UP_RESERVES = ["VariableReserve_ReserveUp", "StaticReserve_ReserveUp"]
 
-DOWN_RESERVES = [
-    "VariableReserve_ReserveDown",
-    "StaticReserve_ReserveDown",
-]
+DOWN_RESERVES = ["VariableReserve_ReserveDown", "StaticReserve_ReserveDown"]
 
 OVERGENERATION_VARIABLE = :γ⁻__P
 UNSERVEDENERGY_VARIABLE = :γ⁺__P

--- a/src/fuel_results.jl
+++ b/src/fuel_results.jl
@@ -140,7 +140,7 @@ function _aggregate_data(res::IS.Results, generators::Dict)
     for (k, v) in generators
         generator_df = DataFrames.DataFrame()
         for l in v
-            colname = "$(l)"
+            colname = Symbol(l)
             if colname in names(all_var)
                 generator_df = hcat(generator_df, all_var[:, colname], makeunique = true)
             end
@@ -193,11 +193,9 @@ function get_stacked_aggregation_data(res::IS.Results, generators::Dict)
         push!(p_legend, string(label))
     end
     parameters = isempty(parameters) ? nothing : reduce(hcat, parameters)
-
     legend = []
     agg_var = []
     for label in new_labels
-        label
         variable = category_aggs[label]
         if !isempty(variable)
             push!(legend, label)
@@ -207,12 +205,12 @@ function get_stacked_aggregation_data(res::IS.Results, generators::Dict)
 
     # TODO: thee following is a hacky way to add the unserved energy slacks to plots
     if UNSERVEDENERGY_VARIABLE in keys(res.variable_values)
-        push!(legend, "Unserved energy")
+        push!(legend, "Unserved Energy")
         push!(agg_var, sum(Matrix(res.variable_values[UNSERVEDENERGY_VARIABLE]), dims = 2))
     end
     # TODO: thee following is a hacky way to add the over generation slacks to plots
     if OVERGENERATION_VARIABLE in keys(res.variable_values)
-        push!(legend, "Over generation")
+        push!(legend, "Over Generation")
         push!(agg_var, sum(Matrix(res.variable_values[OVERGENERATION_VARIABLE]), dims = 2))
     end
     legend = reduce(hcat, legend)

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -216,7 +216,8 @@ function _bar_plot_internal(
                 fillrange = hcat(0, r_data),
             )
             set_display && display(r_plot)
-            !isnothing(save_fig) && Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
+            !isnothing(save_fig) &&
+                Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
             plot_list[Symbol("$(key)_Reserves")] = r_plot
         end
     end
@@ -343,7 +344,8 @@ function _bar_plot_internal(
             end
             r_plot = Plots.plot(r_plots...; layout = (length(results), 1))
             set_display && display(r_plot)
-            !isnothing(save_fig) && Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
+            !isnothing(save_fig) &&
+                Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
             plot_list[Symbol("$(key)_Reserves")] = r_plot
         end
     end
@@ -448,7 +450,8 @@ function _stack_plot_internal(
                 fillrange = hcat(zeros(length(time_range)), r_data),
             )
             set_display && display(r_plot)
-            !isnothing(save_fig) && Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
+            !isnothing(save_fig) &&
+                Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
             plot_list[Symbol("$(key)_Reserves")] = r_plot
         end
     end
@@ -578,7 +581,8 @@ function _stack_plot_internal(
             end
             r_plot = Plots.plot(r_plots...; layout = (length(results), 1))
             set_display && display(r_plot)
-            !isnothing(save_fig) && Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
+            !isnothing(save_fig) &&
+                Plots.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.png"))
             plot_list[Symbol("$(key)_Reserves")] = r_plot
         end
     end

--- a/src/plotly_recipes.jl
+++ b/src/plotly_recipes.jl
@@ -145,12 +145,17 @@ function plotly_stack_gen(
                 )
             end
             r_plot = Plots.PlotlyJS.plot(
-            r_traces,
-            Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
+                r_traces,
+                Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
             )
             set_display && Plots.display(r_plot)
             if !isnothing(save_fig)
-                Plots.PlotlyJS.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.$format"); width = 630, height = 630)
+                Plots.PlotlyJS.savefig(
+                    r_plot,
+                    joinpath(save_fig, "$(key)_Reserves.$format");
+                    width = 630,
+                    height = 630,
+                )
             end
             plot_output[Symbol("$(key)_Reserves")] = r_plot
         end
@@ -280,15 +285,20 @@ function plotly_stack_gen(
                     )
                 end
                 r_plot = Plots.PlotlyJS.plot(
-                r_traces,
-                Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
+                    r_traces,
+                    Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
                 )
                 r_plots = vcat(r_plots, r_plot)
             end
             r_plot = vcat(r_plots...)
             set_display && Plots.display(r_plot)
             if !isnothing(save_fig)
-                Plots.PlotlyJS.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.$format"); width = 630, height = 630)
+                Plots.PlotlyJS.savefig(
+                    r_plot,
+                    joinpath(save_fig, "$(key)_Reserves.$format");
+                    width = 630,
+                    height = 630,
+                )
             end
             plot_output[Symbol("$(key)_Reserves")] = r_plot
         end
@@ -546,7 +556,8 @@ function _bar_plot_internal(
     title = get(kwargs, :title, " ")
     ylabel = _make_bar_ylabel(IS.get_base_power(res))
     plots = plotly_bar_plots(res, seriescolor, ylabel, interval; kwargs...)
-    gen_plots = plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
+    gen_plots =
+        plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
     return PlotList(merge(plots, gen_plots))
 end
 
@@ -563,7 +574,8 @@ function _bar_plot_internal(
     title = get(kwargs, :title, " ")
     ylabel = _make_bar_ylabel(IS.get_base_power(res[1]))
     plots = plotly_bar_plots(res, seriescolor, ylabel, interval; kwargs...)
-    gen_plots = plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
+    gen_plots =
+        plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
     return PlotList(merge(plots, gen_plots))
 end
 
@@ -740,12 +752,12 @@ function plotly_bar_gen(
     seriescolors = set_seriescolor(seriescolor, gens)
     data = []
     for (k, v) in IS.get_variables(res)
-        data = vcat(data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+        data = vcat(data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
     end
     bar_data = hcat(data...) ./ interval
     p_data = []
     for (p, v) in res.parameter_values
-        p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+        p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
     end
     p_data = hcat(p_data...) ./ interval
     for gen in 1:length(gens)
@@ -805,7 +817,7 @@ function plotly_bar_gen(
             r_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
             r_data = []
             for (k, v) in reserve
-                r_data = vcat(r_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+                r_data = vcat(r_data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
             end
             r_data = hcat(r_data...) / interval
             r_gens = collect(keys(reserve))
@@ -825,15 +837,15 @@ function plotly_bar_gen(
                 )
             end
             r_plot = Plots.PlotlyJS.plot(
-            r_traces,
-            Plots.PlotlyJS.Layout(
-                title = "$(key) Reserves",
-                yaxis_title = ylabel,
-                color = seriescolor,
-                barmode = "stack",
+                r_traces,
+                Plots.PlotlyJS.Layout(
+                    title = "$(key) Reserves",
+                    yaxis_title = ylabel,
+                    color = seriescolor,
+                    barmode = "stack",
                 ),
             )
-            set_display&& Plots.display(r_plot)#, Plots.display(down_plot)
+            set_display && Plots.display(r_plot)#, Plots.display(down_plot)
             if !isnothing(save_fig)
                 Plots.PlotlyJS.savefig(
                     r_plot,
@@ -875,12 +887,12 @@ function plotly_bar_gen(
         params = collect(keys((results[i].parameter_values)))
         data = []
         for (k, v) in IS.get_variables(results[i])
-            data = vcat(data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+            data = vcat(data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
         end
         data = hcat(data...) ./ interval
         p_data = []
         for (p, v) in results[i].parameter_values
-            p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+            p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
         end
         p_data = hcat(p_data...) ./ interval
         for gen in 1:length(gens)
@@ -943,7 +955,8 @@ function plotly_bar_gen(
             for i in 1:length(reserve_list)
                 r_data = []
                 for (k, v) in reserve_list[i][key]
-                    r_data = vcat(r_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+                    r_data =
+                        vcat(r_data, [sum(sum(convert(Matrix, v), dims = 2), dims = 1)])
                 end
                 r_data = hcat(r_data...) / interval
                 r_gens = collect(keys(reserve_list[i][key]))
@@ -966,12 +979,12 @@ function plotly_bar_gen(
                     )
                 end
                 r_plot = Plots.PlotlyJS.plot(
-                r_traces,
-                Plots.PlotlyJS.Layout(
-                    title = "$(key) Reserves",
-                    yaxis_title = ylabel,
-                    color = seriescolor,
-                    barmode = "stack",
+                    r_traces,
+                    Plots.PlotlyJS.Layout(
+                        title = "$(key) Reserves",
+                        yaxis_title = ylabel,
+                        color = seriescolor,
+                        barmode = "stack",
                     ),
                 )
                 r_plots = vcat(r_plots, r_plot)
@@ -992,7 +1005,13 @@ function plotly_bar_gen(
     return plot_output
 end
 
-function plotly_bar_plots(results::Array, seriescolor::Array, ylabel::String, interval::Float64; kwargs...)
+function plotly_bar_plots(
+    results::Array,
+    seriescolor::Array,
+    ylabel::String,
+    interval::Float64;
+    kwargs...,
+)
     set_display = get(kwargs, :display, true)
     save_fig = get(kwargs, :save, nothing)
     time_range = results[1].time_stamp
@@ -1019,7 +1038,8 @@ function plotly_bar_plots(results::Array, seriescolor::Array, ylabel::String, in
                         y = sum(convert(Matrix, var)[:, gen], dims = 1) ./ interval,
                         type = "bar",
                         barmode = "stack",
-                        marker_color = seriescolor[gen],)
+                        marker_color = seriescolor[gen],
+                    ),
                 )
             end
             p = Plots.PlotlyJS.plot(
@@ -1048,7 +1068,13 @@ function plotly_bar_plots(results::Array, seriescolor::Array, ylabel::String, in
     return plot_list
 end
 
-function plotly_bar_plots(res::IS.Results, seriescolor::Array, ylabel::String, interval::Float64; kwargs...)
+function plotly_bar_plots(
+    res::IS.Results,
+    seriescolor::Array,
+    ylabel::String,
+    interval::Float64;
+    kwargs...,
+)
     set_display = get(kwargs, :display, true)
     save_fig = get(kwargs, :save, nothing)
     time_range = IS.get_time_stamp(res)
@@ -1109,7 +1135,8 @@ function _fuel_plot_internal(
     stair = get(kwargs, :stair, false)
     stack_title = stair ? "$(title) Stair" : stack_title = "$(title) Stack"
     stacks = plotly_fuel_stack_gen(stack, seriescolor, stack_title, ylabel; kwargs...)
-    bars = plotly_fuel_bar_gen(bar, seriescolor, "$(title) Bar", ylabel, interval; kwargs...)
+    bars =
+        plotly_fuel_bar_gen(bar, seriescolor, "$(title) Bar", ylabel, interval; kwargs...)
     return PlotList(Dict(:Fuel_Stack => stacks, :Fuel_Bar => bars))
 end
 
@@ -1182,7 +1209,7 @@ function _demand_plot_internal(results::Array, backend::Plots.PlotlyJSBackend; k
             seriescolor = length(seriescolor) < n_traces ?
                 repeat(seriescolor, Int64(ceil(n_traces / length(seriescolor)))) :
                 seriescolor
-                n == 1 ? leg = true : leg = false
+            n == 1 ? leg = true : leg = false
             for i in 1:n_traces
                 push!(
                     traces,

--- a/src/plotly_recipes.jl
+++ b/src/plotly_recipes.jl
@@ -1,0 +1,1331 @@
+### PlotlyJS set up
+
+function set_seriescolor(seriescolor::Array, gens::Array)
+    colors = []
+    for i in 1:length(gens)
+        count = i % length(seriescolor)
+        count = count == 0 ? length(seriescolor) : count
+        colors = vcat(colors, seriescolor[count])
+    end
+    return colors
+end
+
+########################################## PLOTLYJS STACK ##########################
+
+function _stack_plot_internal(
+    res::IS.Results,
+    backend::Plots.PlotlyJSBackend,
+    save_fig::Any,
+    set_display::Bool,
+    reserves::Any;
+    kwargs...,
+)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    title = get(kwargs, :title, " ")
+    ylabel = _make_ylabel(IS.get_base_power(res))
+    stack = plotly_stack_plots(res, seriescolor, ylabel; kwargs...)
+    gen_stack = plotly_stack_gen(res, seriescolor, title, ylabel, reserves; kwargs...)
+    return PlotList(merge(stack, gen_stack))
+end
+
+function _stack_plot_internal(
+    res::Array{},
+    backend::Plots.PlotlyJSBackend,
+    save_fig::Any,
+    set_display::Bool,
+    reserves::Any;
+    kwargs...,
+)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    title = get(kwargs, :title, " ")
+    ylabel = _make_ylabel(IS.get_base_power(res[1]))
+    stack = plotly_stack_plots(res, seriescolor, ylabel; kwargs...)
+    gen_stack = plotly_stack_gen(res, seriescolor, title, ylabel, reserves; kwargs...)
+    return PlotList(merge(stack, gen_stack))
+end
+
+function plotly_stack_gen(
+    res::IS.Results,
+    seriescolors::Array,
+    title::String,
+    ylabel::String,
+    reserves::Any;
+    kwargs...,
+)
+    set_display = get(kwargs, :display, true)
+    line_shape = get(kwargs, :stairs, "linear")
+    save_fig = get(kwargs, :save, nothing)
+    format = get(kwargs, :format, "html")
+    plot_output = Dict()
+    traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    gens = collect(keys(IS.get_variables(res)))
+    params = collect(keys(res.parameter_values))
+    time_range = IS.get_time_stamp(res)[:, 1]
+    stack = []
+    plot_stack = Dict()
+    for (k, v) in IS.get_variables(res)
+        stack = vcat(stack, [sum(convert(Matrix, v), dims = 2)])
+    end
+    stack = hcat(stack...)
+    parameters = []
+    for (p, v) in res.parameter_values
+        parameters = vcat(parameters, [sum(convert(Matrix, v), dims = 2)])
+    end
+    parameters = hcat(parameters...)
+    seriescolor = set_seriescolor(seriescolors, gens)
+    for gen in 1:length(gens)
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = gens[gen],
+                x = time_range,
+                y = stack[:, gen],
+                stackgroup = "one",
+                showlegend = true,
+                mode = "lines",
+                line_shape = line_shape,
+                fill = "tonexty",
+                line_color = seriescolor[gen],
+                fillcolor = seriescolor[gen],
+            ),
+        )
+    end
+    if !isempty(params)
+        for param in 1:length(params)
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = params[param],
+                    x = time_range,
+                    y = parameters[:, param],
+                    stackgroup = "two",
+                    mode = "lines",
+                    line_shape = line_shape,
+                    fill = "tozeroy",
+                    line_color = "black",
+                    line_dash = "dash",
+                    line_width = "3",
+                    fillcolor = "rgba(0, 0, 0, 0)",
+                ),
+            )
+        end
+    end
+    p = Plots.PlotlyJS.plot(
+        traces,
+        Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+    )
+    set_display && Plots.display(p)
+    if !isnothing(reserves)
+        reserve_plot = []
+        for (key, reserve) in reserves
+            r_data = []
+            r_gens = []
+            r_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+            for (k, v) in reserve
+                r_data = vcat(r_data, [sum(convert(Matrix, v), dims = 2)])
+                r_gens = vcat(r_gens, k)
+            end
+            r_data = hcat(r_data...)
+            up_seriescolor = set_seriescolor(seriescolors, r_gens)
+            for gen in 1:size(r_gens, 1)
+                push!(
+                    r_traces,
+                    Plots.PlotlyJS.scatter(;
+                        name = r_gens[gen],
+                        x = time_range,
+                        y = r_data[:, gen],
+                        stackgroup = "one",
+                        mode = "lines",
+                        showlegend = true,
+                        line_shape = line_shape,
+                        fill = "tonexty",
+                        line_color = up_seriescolor[gen],
+                        fillcolor = up_seriescolor[gen],
+                    ),
+                )
+            end
+            r_plot = Plots.PlotlyJS.plot(
+            r_traces,
+            Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
+            )
+            set_display && Plots.display(r_plot)
+            if !isnothing(save_fig)
+                Plots.PlotlyJS.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.$format"); width = 630, height = 630)
+            end
+            plot_output[Symbol("$(key)_Reserves")] = r_plot
+        end
+    end
+    stack_title = line_shape == "linear" ? "Stack_Generation" : "Stair_Generation"
+    title = title == " " ? stack_title : replace(title, " " => "_")
+    if !isnothing(save_fig)
+        Plots.PlotlyJS.savefig(
+            p,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    plot_output[Symbol(title)] = p
+    return plot_output
+end
+
+function plotly_stack_gen(
+    results::Array,
+    seriescolors::Array,
+    title::String,
+    ylabel::String,
+    reserve_list::Any;
+    kwargs...,
+)
+    set_display = get(kwargs, :display, true)
+    line_shape = get(kwargs, :stairs, "linear")
+    save_fig = get(kwargs, :save, nothing)
+    format = get(kwargs, :format, "html")
+    plot_output = Dict()
+    plots = []
+    for i in 1:length(results)
+        gens = collect(keys(IS.get_variables(results[i])))
+        params = collect(keys(results[i].parameter_values))
+        time_range = IS.get_time_stamp(results[i])[:, 1]
+        stack = []
+        for (k, v) in IS.get_variables(results[i])
+            stack = vcat(stack, [sum(convert(Matrix, v), dims = 2)])
+        end
+        parameters = []
+        for (p, v) in results[i].parameter_values
+            parameters = vcat(stack, [sum(convert(Matrix, v), dims = 2)])
+        end
+        stack = hcat(stack...)
+        parameters = hcat(parameters...)
+        trace = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        seriescolor = set_seriescolor(seriescolors, gens)
+        line_shape = get(kwargs, :stairs, "linear")
+        i == 1 ? leg = true : leg = false
+        for gen in 1:length(gens)
+            push!(
+                trace,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    showlegend = leg,
+                    x = time_range,
+                    y = stack[:, gen],
+                    stackgroup = "one",
+                    mode = "lines",
+                    line_shape = line_shape,
+                    fill = "tonexty",
+                    line_color = seriescolor[gen],
+                    fillcolor = seriescolor[gen],
+                ),
+            )
+        end
+        if !isempty(params)
+            for param in 1:length(params)
+                push!(
+                    trace,
+                    Plots.PlotlyJS.scatter(;
+                        name = params[param],
+                        x = time_range,
+                        y = parameters[:, param],
+                        showlegend = leg,
+                        stackgroup = "two",
+                        mode = "lines",
+                        line_shape = line_shape,
+                        fill = "tozeroy",
+                        line_color = "black",
+                        line_dash = "dash",
+                        line_width = "3",
+                        fillcolor = "rgba(0, 0, 0, 0)",
+                    ),
+                )
+            end
+        end
+        p = Plots.PlotlyJS.plot(
+            trace,
+            Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+        )
+        plots = vcat(plots, p)
+    end
+    plots = vcat(plots...)
+    set_display && Plots.display(plots)
+    if !isnothing(reserve_list[1])
+        for key in keys(reserve_list[1])
+            r_plots = []
+            for i in 1:length(reserve_list)
+                i == 1 ? leg = true : leg = false
+                time_range = IS.get_time_stamp(results[i])[:, 1]
+                r_data = []
+                r_gens = []
+                r_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+                for (k, v) in reserve_list[i][key]
+                    r_data = vcat(r_data, [sum(convert(Matrix, v), dims = 2)])
+                    r_gens = vcat(r_gens, k)
+                end
+                r_data = hcat(r_data...)
+                r_seriescolor = set_seriescolor(seriescolors, r_gens)
+                for gen in 1:size(r_gens, 1)
+                    push!(
+                        r_traces,
+                        Plots.PlotlyJS.scatter(;
+                            name = r_gens[gen],
+                            x = time_range,
+                            y = r_data[:, gen],
+                            stackgroup = "one",
+                            mode = "lines",
+                            showlegend = leg,
+                            line_shape = line_shape,
+                            fill = "tonexty",
+                            line_color = r_seriescolor[gen],
+                            fillcolor = r_seriescolor[gen],
+                        ),
+                    )
+                end
+                r_plot = Plots.PlotlyJS.plot(
+                r_traces,
+                Plots.PlotlyJS.Layout(title = "$(key) Reserves", yaxis_title = ylabel),
+                )
+                r_plots = vcat(r_plots, r_plot)
+            end
+            r_plot = vcat(r_plots...)
+            set_display && Plots.display(r_plot)
+            if !isnothing(save_fig)
+                Plots.PlotlyJS.savefig(r_plot, joinpath(save_fig, "$(key)_Reserves.$format"); width = 630, height = 630)
+            end
+            plot_output[Symbol("$(key)_Reserves")] = r_plot
+        end
+    end
+    stack_title = line_shape == "linear" ? "Stack_Generation" : "Stair_Generation"
+    title = title == " " ? stack_title : replace(title, " " => "_")
+    if !isnothing(save_fig)
+        Plots.PlotlyJS.savefig(
+            plots,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    plot_output[Symbol(title)] = plots
+    return plot_output
+end
+
+function plotly_stack_plots(
+    results::IS.Results,
+    seriescolor::Array,
+    ylabel::String;
+    kwargs...,
+)
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    line_shape = get(kwargs, :stairs, "linear")
+    plot_list = Dict()
+    for (key, var) in IS.get_variables(results)
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        var = IS.get_variables(results)[key]
+        gens = collect(names(var))
+        seriescolor = set_seriescolor(seriescolor, gens)
+        for gen in 1:length(gens)
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    x = results.time_stamp[:, 1],
+                    y = convert(Matrix, var)[:, gen],
+                    stackgroup = "one",
+                    mode = "lines",
+                    line_shape = line_shape,
+                    fill = "tonexty",
+                    line_color = seriescolor[gen],
+                    fillcolor = seriescolor[gen],
+                ),
+            )
+        end
+        p = Plots.PlotlyJS.plot(
+            traces,
+            Plots.PlotlyJS.Layout(title = "$key", yaxis_title = ylabel),
+        )
+        set_display && Plots.display(p)
+        if !isnothing(save_fig)
+            format = get(kwargs, :format, "html")
+            key_title = line_shape == "linear" ? "$(key)_Stack" : "$(key)_Stair"
+            Plots.PlotlyJS.savefig(
+                p,
+                joinpath(save_fig, "$key_title.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = p
+    end
+    return plot_list
+end
+
+function plotly_stack_plots(results::Array, seriescolor::Array, ylabel::String; kwargs...)
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    line_shape = get(kwargs, :stairs, "linear")
+    _check_matching_variables(results)
+    plot_list = Dict()
+    for key in collect(keys(IS.get_variables(results[1, 1])))
+        plots = []
+        for res in 1:size(results, 2)
+            traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+            var = IS.get_variables(results[1, res])[key]
+            gens = collect(names(var))
+            seriescolor = set_seriescolor(seriescolor, gens)
+            for gen in 1:length(gens)
+                leg = res == 1 ? true : false
+                push!(
+                    traces,
+                    Plots.PlotlyJS.scatter(;
+                        name = gens[gen],
+                        showlegend = leg,
+                        x = results[1, res].time_stamp[:, 1],
+                        y = convert(Matrix, var)[:, gen],
+                        stackgroup = "one",
+                        mode = "lines",
+                        line_shape = line_shape,
+                        fill = "tonexty",
+                        line_color = seriescolor[gen],
+                        fillcolor = seriescolor[gen],
+                    ),
+                )
+            end
+            p = Plots.PlotlyJS.plot(
+                traces,
+                Plots.PlotlyJS.Layout(
+                    title = "$key",
+                    yaxis_title = ylabel,
+                    grid = (rows = 3, columns = 1, pattern = "independent"),
+                ),
+            )
+            plots = vcat(plots, p)
+        end
+        plots = vcat(plots...)
+        set_display && Plots.display(plots)
+        if !isnothing(save_fig)
+            format = get(kwargs, :format, "html")
+            key_title = line_shape == "linear" ? "$(key)_Stack" : "$(key)_Stair"
+            Plots.PlotlyJS.savefig(
+                plots,
+                joinpath(save_fig, "$key_title.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = plots
+    end
+    return plot_list
+end
+
+function plotly_fuel_stack_gen(
+    stacked_gen::StackedGeneration,
+    seriescolor::Array,
+    title::String,
+    ylabel::String;
+    kwargs...,
+)
+    stair = get(kwargs, :stair, false)
+    line_shape = stair ? "hv" : "linear"
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    gens = stacked_gen.labels
+    seriescolor = set_seriescolor(seriescolor, gens)
+    for gen in 1:length(gens)
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = gens[gen],
+                x = stacked_gen.time_range,
+                y = stacked_gen.data_matrix[:, gen],
+                stackgroup = "one",
+                mode = "lines",
+                fill = "tonexty",
+                line_color = seriescolor[gen],
+                fillcolor = seriescolor[gen],
+                line_shape = line_shape,
+            ),
+        )
+    end
+    if get(kwargs, :load, false) == true
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = "Load",
+                x = stacked_gen.time_range,
+                y = stacked_gen.parameters[:, 1],
+                mode = "lines",
+                line_color = "black",
+                line_shape = line_shape,
+                marker_size = 12,
+            ),
+        )
+    end
+
+    p = Plots.PlotlyJS.plot(
+        traces,
+        Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+    )
+    set_display && Plots.display(p)
+    if !isnothing(save_fig)
+        format = get(kwargs, :format, "html")
+        title = replace(title, " " => "_")
+        Plots.PlotlyJS.savefig(
+            p,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    return p
+end
+
+function plotly_fuel_stack_gen(
+    stacks::Array{StackedGeneration},
+    seriescolor::Array,
+    title::String,
+    ylabel::String;
+    kwargs...,
+)
+    line_shape = get(kwargs, :stair, false) ? "hv" : "linear"
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    plots = []
+    for stack in 1:length(stacks)
+        trace = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        gens = stacks[stack].labels
+        seriescolor = set_seriescolor(seriescolor, gens)
+        for gen in 1:length(gens)
+            leg = stack == 1 ? true : false
+            push!(
+                trace,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    showlegend = leg,
+                    x = stacks[stack].time_range,
+                    y = stacks[stack].data_matrix[:, gen],
+                    stackgroup = "one",
+                    mode = "lines",
+                    fill = "tonexty",
+                    line_color = seriescolor[gen],
+                    fillcolor = seriescolor[gen],
+                    line_shape = line_shape,
+                ),
+            )
+        end
+        p = Plots.PlotlyJS.plot(
+            trace,
+            Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+        )
+        plots = vcat(plots, p)
+    end
+    plots = vcat(plots...)
+    set_display && Plots.display(plots)
+    if !isnothing(save_fig)
+        format = get(kwargs, :format, "html")
+        title = replace(title, " " => "_")
+        Plots.PlotlyJS.savefig(
+            plots,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    return plots
+end
+############################# PLOTLYJS BAR ##############################################
+function _bar_plot_internal(
+    res::IS.Results,
+    backend::Plots.PlotlyJSBackend,
+    save_fig::Any,
+    set_display::Bool,
+    interval::Float64,
+    reserves::Any;
+    kwargs...,
+)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    title = get(kwargs, :title, " ")
+    ylabel = _make_bar_ylabel(IS.get_base_power(res))
+    plots = plotly_bar_plots(res, seriescolor, ylabel, interval; kwargs...)
+    gen_plots = plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
+    return PlotList(merge(plots, gen_plots))
+end
+
+function _bar_plot_internal(
+    res::Array,
+    backend::Plots.PlotlyJSBackend,
+    save_fig::Any,
+    set_display::Bool,
+    interval::Float64,
+    reserves::Any;
+    kwargs...,
+)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    title = get(kwargs, :title, " ")
+    ylabel = _make_bar_ylabel(IS.get_base_power(res[1]))
+    plots = plotly_bar_plots(res, seriescolor, ylabel, interval; kwargs...)
+    gen_plots = plotly_bar_gen(res, seriescolor, title, ylabel, interval, reserves; kwargs...)
+    return PlotList(merge(plots, gen_plots))
+end
+
+function plotly_fuel_bar_gen(
+    bar_gen::BarGeneration,
+    seriescolor::Array,
+    title::String,
+    ylabel::String,
+    interval::Float64;
+    kwargs...,
+)
+    time_range = convert.(Dates.DateTime, bar_gen.time_range)
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2] - time_range[1]) * length(time_range),
+    )
+    traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    p_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    gens = bar_gen.labels
+    params = bar_gen.p_labels
+    seriescolor = set_seriescolor(seriescolor, gens)
+    for gen in 1:length(gens)
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = gens[gen],
+                x = ["$time_span, $(time_range[1])"],
+                y = (bar_gen.bar_data[:, gen]) ./ interval,
+                type = "bar",
+                barmode = "stack",
+                stackgroup = "one",
+                marker_color = seriescolor[gen],
+            ),
+        )
+    end
+    #=
+    for param in 1:length(params)
+        push!(
+            p_traces,
+            Plots.PlotlyJS.scatter(;
+                name = params[param],
+                x = ["$time_span, $(time_range[1])"],
+                y = bar_gen.parameters[:, param],
+                type = "bar",
+                stackgroup = "two",
+                marker_color = "rgba(0, 0, 0, 0)",
+                marker_line_color = "rgba(0, 0, 0, 0.6)",
+                marker_line_width=1.5,
+            ),
+        )
+    end
+    =#
+    p = Plots.PlotlyJS.plot(
+        traces,
+        Plots.PlotlyJS.Layout(
+            title = title,
+            yaxis_title = ylabel,
+            color = seriescolor,
+            barmode = "stack",
+        ),
+    )
+    set_display && Plots.display(p)
+    if !isnothing(save_fig)
+        title = title == " " ? "Bar_Generation" : replace(title, " " => "_")
+        format = get(kwargs, :format, "html")
+        Plots.PlotlyJS.savefig(
+            p,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    return p
+end
+
+function plotly_fuel_bar_gen(
+    bar_gen::Array{BarGeneration},
+    seriescolor::Array,
+    title::String,
+    ylabel::String,
+    interval::Float64;
+    kwargs...,
+)
+    time_range = bar_gen[1].time_range
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2] - time_range[1]) * length(time_range),
+    )
+    seriescolor = set_seriescolor(seriescolor, bar_gen[1].labels)
+    plots = []
+    for bar in 1:length(bar_gen)
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        p_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        gens = bar_gen[bar].labels
+        params = bar_gen[bar].p_labels
+        for gen in 1:length(gens)
+            leg = bar == 1 ? true : false
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    showlegend = leg,
+                    x = ["$time_span, $(time_range[1])"],
+                    y = (bar_gen[bar].bar_data[:, gen]) ./ interval,
+                    type = "bar",
+                    barmode = "stack",
+                    marker_color = seriescolor[gen],
+                ),
+            )
+        end
+        #=
+        for param in 1:length(params)
+            push!(
+                p_traces,
+                Plots.PlotlyJS.scatter(;
+                    name = params[param],
+                    x = ["$time_span, $(time_range[1])"],
+                    y = bar_gen.parameters[:, param],
+                    type = "bar",
+                    marker_color = "rgba(0, 0, 0, .1)",
+                ),
+            )
+        end
+        =#
+        p = Plots.PlotlyJS.plot(
+            [traces; p_traces],
+            Plots.PlotlyJS.Layout(
+                title = title,
+                yaxis_title = ylabel,
+                color = seriescolor,
+                barmode = "overlay",
+            ),
+        )
+        plots = vcat(plots, p)
+    end
+    plots = vcat(plots...)
+    set_display && Plots.display(plots)
+    if !isnothing(save_fig)
+        title = title == " " ? "Bar_Generation" : replace(title, " " => "_")
+        format = get(kwargs, :format, "html")
+        Plots.PlotlyJS.savefig(
+            plots,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    return plots
+end
+
+function plotly_bar_gen(
+    res::IS.Results,
+    seriescolor::Array,
+    title::String,
+    ylabel::String,
+    interval::Float64,
+    reserves::Any;
+    kwargs...,
+)
+    time_range = IS.get_time_stamp(res)[:, 1]
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    format = get(kwargs, :format, "html")
+    plot_output = Dict()
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2] - time_range[1]) * length(time_range),
+    )
+    traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    p_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    gens = collect(keys(IS.get_variables(res)))
+    params = collect(keys((res.parameter_values)))
+    seriescolors = set_seriescolor(seriescolor, gens)
+    data = []
+    for (k, v) in IS.get_variables(res)
+        data = vcat(data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+    end
+    bar_data = hcat(data...) ./ interval
+    p_data = []
+    for (p, v) in res.parameter_values
+        p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+    end
+    p_data = hcat(p_data...) ./ interval
+    for gen in 1:length(gens)
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = gens[gen],
+                x = ["$time_span, $(time_range[1])"],
+                y = bar_data[:, gen],
+                type = "bar",
+                barmode = "stack",
+                stackgroup = "one",
+                marker_color = seriescolors[gen],
+            ),
+        )
+    end
+    #=
+    for param in 1:length(params)
+        push!(
+            p_traces,
+            Plots.PlotlyJS.scatter(;
+                name = params[param],
+                x = ["$time_span, $(time_range[1])"],
+                y = param_bar_data[:, param],
+                type = "bar",
+                stackgroup = "two",
+                marker_color = "rgba(0, 0, 0, 0)",
+                marker_line_color = "rgba(0, 0, 0, 0.6)",
+                marker_line_width=1.5,
+            ),
+        )
+    end
+    =#
+    p = Plots.PlotlyJS.plot(
+        traces,
+        Plots.PlotlyJS.Layout(
+            title = title,
+            yaxis_title = ylabel,
+            color = seriescolor,
+            barmode = "stack",
+        ),
+    )
+    set_display && Plots.display(p)
+    title = title == " " ? "Bar_Generation" : replace(title, " " => "_")
+    if !isnothing(save_fig)
+        Plots.PlotlyJS.savefig(
+            p,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    plot_output[Symbol(title)] = p
+    if !isnothing(reserves)
+        reserve_plots = []
+        for (key, reserve) in reserves
+            r_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+            r_data = []
+            for (k, v) in reserve
+                r_data = vcat(r_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+            end
+            r_data = hcat(r_data...) / interval
+            r_gens = collect(keys(reserve))
+            r_seriescolors = set_seriescolor(seriescolor, r_gens)
+            for gen in 1:length(r_gens)
+                push!(
+                    r_traces,
+                    Plots.PlotlyJS.scatter(;
+                        name = r_gens[gen],
+                        x = ["$time_span, $(time_range[1])"],
+                        y = r_data[:, gen],
+                        type = "bar",
+                        barmode = "stack",
+                        stackgroup = "one",
+                        marker_color = r_seriescolors[gen],
+                    ),
+                )
+            end
+            r_plot = Plots.PlotlyJS.plot(
+            r_traces,
+            Plots.PlotlyJS.Layout(
+                title = "$(key) Reserves",
+                yaxis_title = ylabel,
+                color = seriescolor,
+                barmode = "stack",
+                ),
+            )
+            set_display&& Plots.display(r_plot)#, Plots.display(down_plot)
+            if !isnothing(save_fig)
+                Plots.PlotlyJS.savefig(
+                    r_plot,
+                    joinpath(save_fig, "$(key)_Reserves.$format");
+                    width = 630,
+                    height = 630,
+                )
+            end
+            reserve_plots = vcat(reserve_plots, r_plot)
+            plot_output[Symbol("$(key)_Reserves")] = r_plot
+        end
+    end
+    return plot_output
+end
+
+function plotly_bar_gen(
+    results::Array,
+    seriescolor::Array,
+    title::String,
+    ylabel::String,
+    interval::Float64,
+    reserve_list::Any;
+    kwargs...,
+)
+    time_range = IS.get_time_stamp(results[1])[:, 1]
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    format = get(kwargs, :format, "html")
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2] - time_range[1]) * length(time_range),
+    )
+    plots = []
+    plot_output = Dict()
+    for i in 1:length(results)
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        p_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        gens = collect(keys(IS.get_variables(results[i])))
+        seriescolors = set_seriescolor(seriescolor, gens)
+        params = collect(keys((results[i].parameter_values)))
+        data = []
+        for (k, v) in IS.get_variables(results[i])
+            data = vcat(data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+        end
+        data = hcat(data...) ./ interval
+        p_data = []
+        for (p, v) in results[i].parameter_values
+            p_data = vcat(p_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+        end
+        p_data = hcat(p_data...) ./ interval
+        for gen in 1:length(gens)
+            i == 1 ? leg = true : leg = false
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    showlegend = leg,
+                    x = ["$time_span, $(time_range[1])"],
+                    y = data[:, gen],
+                    type = "bar",
+                    barmode = "stack",
+                    marker_color = seriescolors[gen],
+                ),
+            )
+        end
+        #=
+        for param in 1:length(params)
+            push!(
+                p_traces,
+                Plots.PlotlyJS.scatter(;
+                    name = params[param],
+                    x = ["$time_span, $(time_range[1])"],
+                    y = bar_gen.parameters[:, param],
+                    type = "bar",
+                    marker_color = "rgba(0, 0, 0, .1)",
+                ),
+            )
+        end
+        =#
+        p = Plots.PlotlyJS.plot(
+            [traces; p_traces],
+            Plots.PlotlyJS.Layout(
+                title = title,
+                yaxis_title = ylabel,
+                color = seriescolors,
+                barmode = "overlay",
+            ),
+        )
+        plots = vcat(plots, p)
+    end
+    plots = vcat(plots...)
+    set_display && Plots.display(plots)
+    title = title == " " ? "Bar_Generation" : title
+    title = replace(title, " " => "_")
+    plot_output[Symbol(title)] = plots
+    if !isnothing(save_fig)
+        format = get(kwargs, :format, "html")
+        Plots.PlotlyJS.savefig(
+            plots,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    if !isnothing(reserve_list[1])
+        for key in keys(reserve_list[1])
+            r_plots = []
+            for i in 1:length(reserve_list)
+                r_data = []
+                for (k, v) in reserve_list[i][key]
+                    r_data = vcat(r_data, [sum(sum(convert(Matrix, v), dims =2), dims = 1)])
+                end
+                r_data = hcat(r_data...) / interval
+                r_gens = collect(keys(reserve_list[i][key]))
+                r_traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+                r_seriescolor = set_seriescolor(seriescolor, r_gens)
+                for gen in 1:length(r_gens)
+                    i == 1 ? leg = true : leg = false
+                    push!(
+                        r_traces,
+                        Plots.PlotlyJS.scatter(;
+                            name = r_gens[gen],
+                            x = ["$time_span, $(time_range[1])"],
+                            y = r_data[:, gen],
+                            type = "bar",
+                            barmode = "stack",
+                            stackgroup = "one",
+                            marker_color = r_seriescolor[gen],
+                            showlegend = leg,
+                        ),
+                    )
+                end
+                r_plot = Plots.PlotlyJS.plot(
+                r_traces,
+                Plots.PlotlyJS.Layout(
+                    title = "$(key) Reserves",
+                    yaxis_title = ylabel,
+                    color = seriescolor,
+                    barmode = "stack",
+                    ),
+                )
+                r_plots = vcat(r_plots, r_plot)
+            end
+            r_plot = vcat(r_plots...)
+            set_display && Plots.display(r_plot)
+            if !isnothing(save_fig)
+                Plots.PlotlyJS.savefig(
+                    r_plot,
+                    joinpath(save_fig, "$(key)_Reserves.$format");
+                    width = 630,
+                    height = 630,
+                )
+            end
+            plot_output[Symbol("$(key)_Reserves")] = r_plot
+        end
+    end
+    return plot_output
+end
+
+function plotly_bar_plots(results::Array, seriescolor::Array, ylabel::String, interval::Float64; kwargs...)
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    time_range = results[1].time_stamp
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2, 1] - time_range[1, 1]) *
+        size(time_range, 1),
+    )
+    plot_list = Dict()
+    for key in collect(keys(IS.get_variables(results[1])))
+        plots = []
+        for res in 1:length(results)
+            var = IS.get_variables(results[res])[key]
+            traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+            gens = collect(names(var))
+            seriescolor = set_seriescolor(seriescolor, gens)
+            for gen in 1:length(gens)
+                leg = res == 1 ? true : false
+                push!(
+                    traces,
+                    Plots.PlotlyJS.scatter(;
+                        name = gens[gen],
+                        showlegend = leg,
+                        x = ["$time_span, $(time_range[1, 1])"],
+                        y = sum(convert(Matrix, var)[:, gen], dims = 1) ./ interval,
+                        type = "bar",
+                        barmode = "stack",
+                        marker_color = seriescolor[gen],)
+                )
+            end
+            p = Plots.PlotlyJS.plot(
+                traces,
+                Plots.PlotlyJS.Layout(
+                    title = "$key",
+                    yaxis_title = ylabel,
+                    barmode = "stack",
+                ),
+            )
+            plots = vcat(plots, p)
+        end
+        plot = vcat(plots...)
+        set_display && Plots.display(plot)
+        if !isnothing(save_fig)
+            format = get(kwargs, :format, "html")
+            Plots.PlotlyJS.savefig(
+                plot,
+                joinpath(save_fig, "$(key)_Bar.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = plot
+    end
+    return plot_list
+end
+
+function plotly_bar_plots(res::IS.Results, seriescolor::Array, ylabel::String, interval::Float64; kwargs...)
+    set_display = get(kwargs, :display, true)
+    save_fig = get(kwargs, :save, nothing)
+    time_range = IS.get_time_stamp(res)
+    time_span = IS.convert_compound_period(
+        convert(Dates.TimePeriod, time_range[2, 1] - time_range[1, 1]) *
+        size(time_range, 1),
+    )
+    plot_list = Dict()
+    for (key, var) in IS.get_variables(res)
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        gens = collect(names(var))
+        seriescolor = set_seriescolor(seriescolor, gens)
+        for gen in 1:length(gens)
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = gens[gen],
+                    x = ["$time_span, $(time_range[1, 1])"],
+                    y = sum(convert(Matrix, var)[:, gen], dims = 1) ./ interval,
+                    type = "bar",
+                    barmode = "stack",
+                    marker_color = seriescolor[gen],
+                ),
+            )
+        end
+        p = Plots.PlotlyJS.plot(
+            traces,
+            Plots.PlotlyJS.Layout(barmode = "stack", title = "$key", yaxis_title = ylabel),
+        )
+        set_display && Plots.display(p)
+        if !isnothing(save_fig)
+            format = get(kwargs, :format, "html")
+            Plots.PlotlyJS.savefig(
+                p,
+                joinpath(save_fig, "$(key)_Bar.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = p
+    end
+    return plot_list
+end
+
+###################################### PLOTLYJS FUEL ################################
+function _fuel_plot_internal(
+    stack::Union{StackedGeneration, Array{StackedGeneration}},
+    bar::Union{BarGeneration, Array{BarGeneration}},
+    seriescolor::Array,
+    backend::Plots.PlotlyJSBackend,
+    save_fig::Any,
+    set_display::Bool,
+    title::String,
+    ylabel::String,
+    interval::Float64;
+    kwargs...,
+)
+    stair = get(kwargs, :stair, false)
+    stack_title = stair ? "$(title) Stair" : stack_title = "$(title) Stack"
+    stacks = plotly_fuel_stack_gen(stack, seriescolor, stack_title, ylabel; kwargs...)
+    bars = plotly_fuel_bar_gen(bar, seriescolor, "$(title) Bar", ylabel, interval; kwargs...)
+    return PlotList(Dict(:Fuel_Stack => stacks, :Fuel_Bar => bars))
+end
+
+############################## PLOTLYJS DEMAND PLOTS ##########################
+
+function _demand_plot_internal(res::IS.Results, backend::Plots.PlotlyJSBackend; kwargs...)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    line_shape = get(kwargs, :stair, false) ? "hv" : "linear"
+    save_fig = get(kwargs, :save, nothing)
+    set_display = get(kwargs, :display, true)
+    ylabel = _make_ylabel(IS.get_base_power(res))
+    plot_list = Dict()
+    for (key, parameters) in res.parameter_values
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        param_names = names(parameters)
+        n_traces = length(param_names)
+        seriescolor = length(seriescolor) < n_traces ?
+            repeat(seriescolor, Int64(ceil(n_traces / length(seriescolor)))) : seriescolor
+        title = get(kwargs, :title, "$key")
+        for i in 1:n_traces
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = param_names[i],
+                    x = res.time_stamp[:, 1],
+                    y = parameters[:, param_names[i]],
+                    stackgroup = "one",
+                    mode = "lines",
+                    fill = "tonexty",
+                    line_color = seriescolor[i],
+                    line_shape = line_shape,
+                ),
+            )
+        end
+        format = get(kwargs, :format, "html")
+        p = Plots.PlotlyJS.plot(
+            traces,
+            Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+        )
+        set_display && Plots.display(p)
+        if !isnothing(save_fig)
+            title = replace(title, " " => "_")
+            Plots.PlotlyJS.savefig(
+                p,
+                joinpath(save_fig, "$title.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = p
+    end
+    return PlotList(plot_list)
+end
+
+function _demand_plot_internal(results::Array, backend::Plots.PlotlyJSBackend; kwargs...)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    save_fig = get(kwargs, :save, nothing)
+    set_display = get(kwargs, :display, true)
+    ylabel = _make_ylabel(IS.get_base_power(results[1]))
+    line_shape = get(kwargs, :stair, false) ? "hv" : "linear"
+    plot_list = Dict()
+    for (key, parameters) in results[1].parameter_values
+        plots = []
+        title = get(kwargs, :title, "$key")
+        for n in 1:length(results)
+            traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+            parameters = results[n].parameter_values[key]
+            p_names = collect(names(parameters))
+            n_traces = length(p_names)
+            seriescolor = length(seriescolor) < n_traces ?
+                repeat(seriescolor, Int64(ceil(n_traces / length(seriescolor)))) :
+                seriescolor
+                n == 1 ? leg = true : leg = false
+            for i in 1:n_traces
+                push!(
+                    traces,
+                    Plots.PlotlyJS.scatter(;
+                        name = p_names[i],
+                        x = results[n].time_stamp[:, 1],
+                        y = parameters[:, p_names[i]],
+                        stackgroup = "one",
+                        mode = "lines",
+                        fill = "tonexty",
+                        line_color = seriescolor[i],
+                        showlegend = leg,
+                    ),
+                )
+            end
+            title = get(kwargs, :title, "$key")
+            p = Plots.PlotlyJS.plot(
+                traces,
+                Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+            )
+            plots = vcat(plots, p)
+        end
+        plots = vcat(plots...)
+        set_display && Plots.display(plots)
+        if !isnothing(save_fig)
+            format = get(kwargs, :format, "html")
+            Plots.PlotlyJS.savefig(
+                plots,
+                joinpath(save_fig, "$title.$format");
+                width = 630,
+                height = 630,
+            )
+        end
+        plot_list[key] = plots
+    end
+    return PlotList(plot_list)
+end
+
+################################ SYSTEM DEMAND PLOTS ###################################
+
+function _demand_plot_internal(
+    parameters::DataFrames.DataFrame,
+    basepower::Float64,
+    backend::Plots.PlotlyJSBackend;
+    kwargs...,
+)
+    line_shape = get(kwargs, :stair, false) ? "hv" : "linear"
+    save_fig = get(kwargs, :save, nothing)
+    set_display = get(kwargs, :display, true)
+    ylabel = _make_ylabel(basepower)
+    plot_list = Dict()
+    traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+    data = DataFrames.select(parameters, DataFrames.Not(:timestamp))
+    param_names = names(data)
+    n_traces = length(param_names)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)#repeat([PLOTLY_DEFAULT], n_traces))
+    title = get(kwargs, :title, "PowerLoad")
+    for i in 1:n_traces
+        push!(
+            traces,
+            Plots.PlotlyJS.scatter(;
+                name = param_names[i],
+                x = parameters[:, :timestamp],
+                y = data[:, param_names[i]],
+                stackgroup = "one",
+                mode = "lines",
+                fill = "tonexty",
+                line_color = seriescolor[i],
+                line_shape = line_shape,
+            ),
+        )
+    end
+    format = get(kwargs, :format, "html")
+    p = Plots.PlotlyJS.plot(
+        traces,
+        Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+    )
+    set_display && Plots.display(p)
+    if !isnothing(save_fig)
+        title = replace(title, " " => "_")
+        Plots.PlotlyJS.savefig(
+            p,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    plot_list[Symbol(title)] = p
+    return PlotList(plot_list)
+end
+
+function _demand_plot_internal(
+    parameters::Array,
+    basepower::Array,
+    backend::Plots.PlotlyJSBackend;
+    kwargs...,
+)
+    seriescolor = get(kwargs, :seriescolor, PLOTLY_DEFAULT)
+    save_fig = get(kwargs, :save, nothing)
+    set_display = get(kwargs, :display, true)
+    line_shape = get(kwargs, :stair, false) ? "hv" : "linear"
+    plot_list = Dict()
+    plots = []
+    title = get(kwargs, :title, "PowerLoad")
+    for i in 1:length(parameters)
+        data = DataFrames.select(parameters[i], DataFrames.Not(:timestamp))
+        p_names = collect(names(data))
+        ylabel = _make_ylabel(basepower[i])
+        traces = Plots.PlotlyJS.GenericTrace{Dict{Symbol, Any}}[]
+        for n in 1:length(p_names)
+            i == 1 ? leg = true : leg = false
+            push!(
+                traces,
+                Plots.PlotlyJS.scatter(;
+                    name = p_names[n],
+                    x = parameters[i][:, :timestamp],
+                    y = data[:, p_names[n]],
+                    stackgroup = "one",
+                    mode = "lines",
+                    fill = "tonexty",
+                    line_color = seriescolor[n],
+                    showlegend = leg,
+                ),
+            )
+        end
+        p = Plots.PlotlyJS.plot(
+            traces,
+            Plots.PlotlyJS.Layout(title = title, yaxis_title = ylabel),
+        )
+        plots = vcat(plots, p)
+    end
+    plots = vcat(plots...)
+    set_display && Plots.display(plots)
+    if !isnothing(save_fig)
+        format = get(kwargs, :format, "html")
+        title = replace(title, " " => "_")
+        Plots.PlotlyJS.savefig(
+            plots,
+            joinpath(save_fig, "$title.$format");
+            width = 630,
+            height = 630,
+        )
+    end
+    plot_list[Symbol(title)] = plots
+    return PlotList(plot_list)
+end


### PR DESCRIPTION
- fixed issue with bar plots not getting divided by interval in an hour
- separates code between plotlyjs and gr (default)
- makes reserves plots (up and down) when *reserves = true* gets called
- fixes a bug with the factor of some plots
- generally cleans up some code, shortens if statements to be ? : 
- removes some repetitivity

@claytonpbarrows 