### PR TITLE
Switch to using `nameof` instead of just `string` in `make_fuel_dictionary`

### DIFF
--- a/src/fuel_results.jl
+++ b/src/fuel_results.jl
@@ -86,7 +86,7 @@ function make_fuel_dictionary(sys::PSY.System, mapping::Dict{NamedTuple, String}
                 PSY.get_prime_mover(gen) : nothing
             category = get_generator_category(fuel, pm, mapping)
         end
-        push!(gen_categories["$category"], (string(typeof(gen)), (PSY.get_name(gen))))
+        push!(gen_categories["$category"], (string(nameof(typeof(gen))), PSY.get_name(gen)))
     end
     [delete!(gen_categories, "$k") for (k, v) in gen_categories if isempty(v)]
     return gen_categories

--- a/src/plot_data.jl
+++ b/src/plot_data.jl
@@ -444,7 +444,7 @@ function categorize_data(
                 category_data = data[var_types[component_type]]
                 colname =
                     typeof(names(category_data)[1]) == String ? "$variable" :
-                    Symbol(variable)
+                    variable
                 DataFrames.insertcols!(
                     category_df,
                     (colname => category_data[:, colname]),

--- a/src/plot_data.jl
+++ b/src/plot_data.jl
@@ -439,12 +439,12 @@ function categorize_data(
     var_types = Dict(zip(last.(split.(string.(keys(data)), "_")), keys(data)))
     for (category, list) in aggregation
         category_df = DataFrames.DataFrame()
-        for tuple in list
-            if haskey(var_types, tuple[1])
-                category_data = data[var_types[tuple[1]]]
+        for (component_type, variable) in list
+            if haskey(var_types, component_type)
+                category_data = data[var_types[component_type]]
                 colname =
-                    typeof(names(category_data)[1]) == String ? "$(tuple[2])" :
-                    Symbol(tuple[2])
+                    typeof(names(category_data)[1]) == String ? "$variable" :
+                    Symbol(variable)
                 DataFrames.insertcols!(
                     category_df,
                     (colname => category_data[:, colname]),

--- a/src/plot_data.jl
+++ b/src/plot_data.jl
@@ -442,9 +442,7 @@ function categorize_data(
         for (component_type, variable) in list
             if haskey(var_types, component_type)
                 category_data = data[var_types[component_type]]
-                colname =
-                    typeof(names(category_data)[1]) == String ? "$variable" :
-                    variable
+                colname = typeof(names(category_data)[1]) == String ? "$variable" : variable
                 DataFrames.insertcols!(
                     category_df,
                     (colname => category_data[:, colname]),


### PR DESCRIPTION
Currently, `make_fuel_dictionary` is sensitive to whether `PowerSystems` is in the current namespace.

The function `make_fuel_dictionary` created a dictionary with values using `string(typeof(gen))`. If `PowerSystems` is not in the namespace, then the dictionary will not find the corresponding tags when `categorize_data` is called in `plot_fuel` since the results will not have `PowerSystems` prepended to the generator types.

This pull request changes `string(typeof(gen))` to `string(nameof(typeof(gen)))`. Here, `nameof` does not depend on the namespace of the package.